### PR TITLE
Fix buggy scripts.

### DIFF
--- a/lectures/05_Running_DFT_on_PACE.ipynb
+++ b/lectures/05_Running_DFT_on_PACE.ipynb
@@ -94,6 +94,8 @@
     "\n",
     "make clean; make\n",
     "\n",
+    "cd ~/data/\n",
+    "\n",
     "#after compiling the code, clone the sparc-dft-api package\n",
     "git clone https://github.com/SPARC-X/sparc-dft-api.git\n",
     "\n",
@@ -137,7 +139,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What is this doing? It is adding things to the PATH and PYTHONPATH. Linux looks for commands and programs to run by checking through the variable PATH to find the program/command we've asked for. After setting the environment variables in the environment file, we can source it while running the DFT calculation by specifying it in your PBS script:"
+    "What is this doing? It is adding things to the PATH and PYTHONPATH. Linux looks for commands and programs to run by checking through the variable PATH to find the program/command we've asked for. Please note that the user should substitute ssahoo41 with your corresponding username. After setting the environment variables in the environment file, we can source it while running the DFT calculation by specifying it in your PBS script:"
    ]
   },
   {


### PR DESCRIPTION
I'm part of the VIP for Big Data and Quantum Mechanics. At any rate, while working out how to make the scripts work, I noticed that the paths which were exported and where some of the cloned directories were installed didn't make any sense. After backtracking, it became obvious that the script ```sparc_env.sh``` was cloning the libraries into the wrong directory paths. We never changed our directories back to the data folder from where we are running all our experiments. 

That aside, I also added another line where I suggested that the user switch ```ssahoo41``` with their own username, as on PACE, they do not have the permissions to access other people's data folders. (I'm not completely sure about this -- at least you can't cd into them, thank god) Anyways, those are my suggestions. 